### PR TITLE
update v6_to_main from main and fix typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ set_target_properties(ccpp_physics PROPERTIES VERSION ${PROJECT_VERSION}
 target_include_directories(ccpp_physics PUBLIC
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
-target_link_libraries(ccpp_physics PUBLIC w3nco::w3nco_d NetCDF::NetCDF_Fortran)
+target_link_libraries(ccpp_physics PUBLIC w3emc::w3emc_d NetCDF::NetCDF_Fortran)
 
 # Define where to install the library
 install(TARGETS ccpp_physics

--- a/physics/GFS_time_vary_pre.scm.F90
+++ b/physics/GFS_time_vary_pre.scm.F90
@@ -122,7 +122,7 @@
         else if (w3kindreal == 4) then
            rinc4(1:5) = 0
            call w3difdat(jdat,idat,4,rinc4)
-           sec = rina4c(4)
+           sec = rinc4(4)
         else
            write(0,*)' FATAL ERROR: Invalid w3kindreal'
            call abort

--- a/physics/sfc_diag_post.F90
+++ b/physics/sfc_diag_post.F90
@@ -42,14 +42,14 @@
         errmsg = ''
         errflg = 0
 
-        if (lsm == lsm_noahmp) then
-          do i=1,im
-            if(dry(i)) then
-              t2m(i) = t2mmp(i)
-              q2m(i) = q2mp(i)
-            endif
-          enddo
-        endif
+!       if (lsm == lsm_noahmp) then
+!         do i=1,im
+!           if(dry(i)) then
+!             t2m(i) = t2mmp(i)
+!             q2m(i) = q2mp(i)
+!           endif
+!         enddo
+!       endif
 
         if (lssav) then
           do i=1,im


### PR DESCRIPTION
This updates the v6_to_main branch in preparation for UFS merging and fixes a typo introduced in a past PR in an SCM-only version of a scheme. This needs to be merged before starting the UFS merge process.